### PR TITLE
feat: upgrade to libdns v1 beta APIs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @SamyDjemai

--- a/client.go
+++ b/client.go
@@ -49,12 +49,15 @@ func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Rec
 	}
 
 	for _, entry := range zoneRecords.Records {
-		record := libdns.Record{
-			Name:  libdns.RelativeName(entry.Name, zone),
-			Value: entry.Data,
-			Type:  string(entry.Type),
-			TTL:   time.Duration(entry.TTL) * time.Second,
-			ID:    entry.ID,
+		rr := libdns.RR{
+			Name: libdns.RelativeName(entry.Name, zone),
+			Type: string(entry.Type),
+			Data: entry.Data,
+			TTL:  time.Duration(entry.TTL) * time.Second,
+		}
+		record, err := rr.Parse()
+		if err != nil {
+			return records, err
 		}
 		records = append(records, record)
 	}
@@ -70,18 +73,20 @@ func (p *Provider) addDNSEntry(ctx context.Context, zone string, record libdns.R
 		return record, err
 	}
 
+	rr := record.RR()
+
 	domainAPI := domain.NewAPI(p.client)
-	records, err := domainAPI.UpdateDNSZoneRecords(&domain.UpdateDNSZoneRecordsRequest{
+	_, err = domainAPI.UpdateDNSZoneRecords(&domain.UpdateDNSZoneRecordsRequest{
 		DNSZone: zone,
 		Changes: []*domain.RecordChange{
 			{
 				Add: &domain.RecordChangeAdd{
 					Records: []*domain.Record{
 						{
-							Name: libdns.AbsoluteName(record.Name, zone),
-							Data: record.Value,
-							Type: domain.RecordType(record.Type),
-							TTL:  uint32(record.TTL.Seconds()),
+							Name: libdns.AbsoluteName(rr.Name, zone),
+							Type: domain.RecordType(rr.Type),
+							Data: rr.Data,
+							TTL:  uint32(rr.TTL.Seconds()),
 						},
 					},
 				},
@@ -90,9 +95,6 @@ func (p *Provider) addDNSEntry(ctx context.Context, zone string, record libdns.R
 	})
 	if err != nil {
 		return record, err
-	}
-	if len(records.Records) > 0 {
-		record.ID = records.Records[0].ID
 	}
 	return record, nil
 }
@@ -105,13 +107,21 @@ func (p *Provider) removeDNSEntry(ctx context.Context, zone string, record libdn
 	if err != nil {
 		return record, err
 	}
+
+	rr := record.RR()
+
 	domainAPI := domain.NewAPI(p.client)
 	_, err = domainAPI.UpdateDNSZoneRecords(&domain.UpdateDNSZoneRecordsRequest{
 		DNSZone: zone,
 		Changes: []*domain.RecordChange{
 			{
 				Delete: &domain.RecordChangeDelete{
-					ID: &record.ID,
+					IDFields: &domain.RecordIdentifier{
+						Name: libdns.AbsoluteName(rr.Name, zone),
+						Type: domain.RecordType(rr.Type),
+						Data: &rr.Data,
+						TTL:  scw.Uint32Ptr(uint32(rr.TTL.Seconds())),
+					},
 				},
 			},
 		},
@@ -130,19 +140,27 @@ func (p *Provider) updateDNSEntry(ctx context.Context, zone string, record libdn
 	if err != nil {
 		return record, err
 	}
+
+	rr := record.RR()
+
 	domainAPI := domain.NewAPI(p.client)
 	_, err = domainAPI.UpdateDNSZoneRecords(&domain.UpdateDNSZoneRecordsRequest{
 		DNSZone: zone,
 		Changes: []*domain.RecordChange{
 			{
 				Set: &domain.RecordChangeSet{
-					ID: &record.ID,
+					IDFields: &domain.RecordIdentifier{
+						Name: libdns.AbsoluteName(rr.Name, zone),
+						Type: domain.RecordType(rr.Type),
+						Data: &rr.Data,
+						TTL:  scw.Uint32Ptr(uint32(rr.TTL.Seconds())),
+					},
 					Records: []*domain.Record{
 						{
-							Name: libdns.AbsoluteName(record.Name, zone),
-							Data: record.Value,
-							Type: domain.RecordType(record.Type),
-							TTL:  uint32(record.TTL.Seconds()),
+							Name: libdns.AbsoluteName(rr.Name, zone),
+							Type: domain.RecordType(rr.Type),
+							Data: rr.Data,
+							TTL:  uint32(rr.TTL.Seconds()),
 						},
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/libdns/scaleway
 
-go 1.19
+go 1.24
 
 require (
-	github.com/libdns/libdns v0.2.1
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.24
+	github.com/libdns/libdns v1.0.0-beta.1
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.33
 )
 
 require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.24 h1:EcdtP9t+TRmJep0KOUed7Mzw40nIIiMA9HBVxGf8ino=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.24/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
+github.com/libdns/libdns v1.0.0-beta.1 h1:KIf4wLfsrEpXpZ3vmc/poM8zCATXT2klbdPe6hyOBjQ=
+github.com/libdns/libdns v1.0.0-beta.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.33 h1:KhF0WejiUTDbL5X55nXowP7zNopwpowa6qaMAWyIE+0=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.33/go.mod h1:792k1RTU+5JeMXm35/e2Wgp71qPH/DmDoZrRc+EFZDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/provider.go
+++ b/provider.go
@@ -32,7 +32,13 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		newRecord.TTL = newRecord.TTL * time.Second
+
+		rr := newRecord.RR()
+		rr.TTL = time.Duration(rr.TTL) * time.Second
+		newRecord, err = rr.Parse()
+		if err != nil {
+			return nil, err
+		}
 		appendedRecords = append(appendedRecords, newRecord)
 	}
 
@@ -48,7 +54,13 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		if err != nil {
 			return setRecords, err
 		}
-		setRecord.TTL = time.Duration(setRecord.TTL) * time.Second
+
+		rr := setRecord.RR()
+		rr.TTL = time.Duration(rr.TTL) * time.Second
+		setRecord, err = rr.Parse()
+		if err != nil {
+			return nil, err
+		}
 		setRecords = append(setRecords, setRecord)
 	}
 	return setRecords, nil
@@ -63,7 +75,12 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		deletedRecord.TTL = deletedRecord.TTL * time.Second
+		rr := deletedRecord.RR()
+		rr.TTL = time.Duration(rr.TTL) * time.Second
+		deletedRecord, err = rr.Parse()
+		if err != nil {
+			return nil, err
+		}
 		deletedRecords = append(deletedRecords, deletedRecord)
 	}
 


### PR DESCRIPTION
Reworks this package to be compatible with the new libdns 1.0 APIs. The Scaleway SDK lets us choose DNS records with ID fields rather than an ID, which seems cleaner.