### PR TITLE
fix: code smells and consistency improvements

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -16,9 +16,9 @@ func main() {
 		fmt.Printf("SECRET_KEY not set\n")
 		return
 	}
-	organisationID := os.Getenv("ORGANISATION_ID")
-	if organisationID == "" {
-		fmt.Printf("ORGANISATION_ID not set\n")
+	organizationID := os.Getenv("ORGANIZATION_ID")
+	if organizationID == "" {
+		fmt.Printf("ORGANIZATION_ID not set\n")
 		return
 	}
 	zone := os.Getenv("ZONE")
@@ -28,12 +28,13 @@ func main() {
 	}
 	provider := scaleway.Provider{
 		SecretKey:      secretKey,
-		OrganizationID: organisationID,
+		OrganizationID: organizationID,
 	}
 
 	records, err := provider.GetRecords(context.TODO(), zone)
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
+		return
 	}
 
 	testName := "libdns-test"
@@ -66,6 +67,7 @@ func main() {
 		}})
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())
+			return
 		}
 	} else {
 		fmt.Printf("Creating new entry for %s\n", testName)
@@ -77,6 +79,7 @@ func main() {
 		}})
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())
+			return
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ type Client struct {
 	mutex  sync.Mutex
 }
 
+// getClient initializes the Scaleway API client if not already set.
 func (p *Provider) getClient() error {
 	if p.client == nil {
 		var err error
@@ -27,6 +28,14 @@ func (p *Provider) getClient() error {
 		}
 	}
 	return nil
+}
+
+// convertRecord applies TTL conversion to a record.
+// Scaleway API uses TTL in seconds, libdns uses time.Duration.
+func convertRecord(record libdns.Record) (libdns.Record, error) {
+	rr := record.RR()
+	rr.TTL = time.Duration(rr.TTL) * time.Second
+	return rr.Parse()
 }
 
 func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Record, error) {
@@ -45,7 +54,7 @@ func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Rec
 		DNSZone: zone,
 	})
 	if err != nil {
-		return records, err
+		return nil, err
 	}
 
 	for _, entry := range zoneRecords.Records {
@@ -57,7 +66,7 @@ func (p *Provider) getDNSEntries(ctx context.Context, zone string) ([]libdns.Rec
 		}
 		record, err := rr.Parse()
 		if err != nil {
-			return records, err
+			return nil, err
 		}
 		records = append(records, record)
 	}
@@ -96,7 +105,7 @@ func (p *Provider) addDNSEntry(ctx context.Context, zone string, record libdns.R
 	if err != nil {
 		return record, err
 	}
-	return record, nil
+	return convertRecord(record)
 }
 
 func (p *Provider) removeDNSEntry(ctx context.Context, zone string, record libdns.Record) (libdns.Record, error) {
@@ -129,7 +138,7 @@ func (p *Provider) removeDNSEntry(ctx context.Context, zone string, record libdn
 	if err != nil {
 		return record, err
 	}
-	return record, nil
+	return convertRecord(record)
 }
 
 func (p *Provider) updateDNSEntry(ctx context.Context, zone string, record libdns.Record) (libdns.Record, error) {
@@ -170,5 +179,5 @@ func (p *Provider) updateDNSEntry(ctx context.Context, zone string, record libdn
 	if err != nil {
 		return record, err
 	}
-	return record, nil
+	return convertRecord(record)
 }

--- a/provider.go
+++ b/provider.go
@@ -2,7 +2,6 @@ package scaleway
 
 import (
 	"context"
-	"time"
 
 	"github.com/libdns/libdns"
 )
@@ -15,12 +14,7 @@ type Provider struct {
 
 // GetRecords lists all the records in the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	records, err := p.getDNSEntries(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	return records, nil
+	return p.getDNSEntries(ctx, zone)
 }
 
 // AppendRecords adds records to the zone. It returns the records that were added.
@@ -29,13 +23,6 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 
 	for _, record := range records {
 		newRecord, err := p.addDNSEntry(ctx, zone, record)
-		if err != nil {
-			return nil, err
-		}
-
-		rr := newRecord.RR()
-		rr.TTL = time.Duration(rr.TTL) * time.Second
-		newRecord, err = rr.Parse()
 		if err != nil {
 			return nil, err
 		}
@@ -52,13 +39,6 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	for _, record := range records {
 		setRecord, err := p.updateDNSEntry(ctx, zone, record)
 		if err != nil {
-			return setRecords, err
-		}
-
-		rr := setRecord.RR()
-		rr.TTL = time.Duration(rr.TTL) * time.Second
-		setRecord, err = rr.Parse()
-		if err != nil {
 			return nil, err
 		}
 		setRecords = append(setRecords, setRecord)
@@ -72,12 +52,6 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 
 	for _, record := range records {
 		deletedRecord, err := p.removeDNSEntry(ctx, zone, record)
-		if err != nil {
-			return nil, err
-		}
-		rr := deletedRecord.RR()
-		rr.TTL = time.Duration(rr.TTL) * time.Second
-		deletedRecord, err = rr.Parse()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR addresses several code smells and potential issues:

- DRY violation: Extracted TTL conversion into a reusable convertRecord helper function, removing duplicate code from AppendRecords, SetRecords, and DeleteRecords
- Inconsistent error handling: Fixed getDNSEntries to return nil on error (was returning partially populated slice), and fixed SetRecords to return nil instead of partial results
- Dead code: Simplified GetRecords to direct return instead of pass-through wrapper
- Example fixes: Fixed typo organisationID to organizationID and added proper error handling with early returns
- Cleanup: Removed unused time import from provider.go

All changes maintain the original locking behavior for thread-safety.